### PR TITLE
feat(db): add sql migration for parent_task_id

### DIFF
--- a/backend/db/add_parent_task_id.sql
+++ b/backend/db/add_parent_task_id.sql
@@ -1,0 +1,5 @@
+-- Add parent_task_id column to tasks table to support subtasks structure
+-- This fixes the error: "column tasks.parent_task_id does not exist"
+
+ALTER TABLE public.tasks
+ADD COLUMN parent_task_id integer REFERENCES public.tasks(id) ON DELETE CASCADE;


### PR DESCRIPTION
Creates a SQL migration file `backend/db/add_parent_task_id.sql` to add the `parent_task_id` column to the `tasks` table. This resolves the backend error "column tasks.parent_task_id does not exist" caused by the `TaskRepository` expecting a self-referencing task structure for subtasks. The existing `subTask` table is unused by the current repository logic.