### PR TITLE
Unify dark mode theme with bluish tones

### DIFF
--- a/frontend/src/features/calendar/CalendarPage.jsx
+++ b/frontend/src/features/calendar/CalendarPage.jsx
@@ -29,7 +29,7 @@ function CreateEventModal({ onClose, onCreate, selectedDate }) {
 
   return (
     <div className="fixed inset-0 bg-black/30 backdrop-blur-sm z-50 flex items-center justify-center p-4 animate-in fade-in duration-200">
-      <div className={`${darkMode ? 'bg-gray-800' : 'bg-white'} rounded-xl shadow-2xl w-full max-w-md animate-in zoom-in-95 duration-300`}>
+      <div className="bg-card rounded-xl shadow-2xl w-full max-w-md animate-in zoom-in-95 duration-300 border border-border">
         <div className="p-6">
           <div className="flex justify-between items-center mb-6">
             <div className="flex items-center gap-3">
@@ -37,8 +37,8 @@ function CreateEventModal({ onClose, onCreate, selectedDate }) {
                 <Plus size={24} className="text-green-600" />
               </div>
               <div>
-                <h2 className={`text-xl font-bold ${darkMode ? 'text-white' : 'text-gray-900'}`}>Nuevo Evento</h2>
-                <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>Crea un evento en tu calendario</p>
+                <h2 className="text-xl font-bold text-foreground">Nuevo Evento</h2>
+                <p className="text-sm text-muted-foreground">Crea un evento en tu calendario</p>
               </div>
             </div>
             <Button variant="ghost" size="icon" onClick={onClose}>
@@ -48,20 +48,20 @@ function CreateEventModal({ onClose, onCreate, selectedDate }) {
 
           <div className="space-y-4">
             <div>
-              <Label className={darkMode ? 'text-gray-300' : ''}>Título *</Label>
+              <Label>Título *</Label>
               <Input
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="Título del evento"
-                className={`mt-1 ${darkMode ? 'bg-gray-700 border-gray-600 text-white' : ''}`}
+                className="mt-1 bg-background border-border text-foreground"
               />
             </div>
             <div>
-              <Label className={darkMode ? 'text-gray-300' : ''}>Tipo</Label>
+              <Label>Tipo</Label>
               <select
                 value={type}
                 onChange={(e) => setType(e.target.value)}
-                className={`w-full mt-1 px-3 py-2 rounded-lg border ${darkMode ? 'bg-gray-700 border-gray-600 text-white' : 'border-gray-300'}`}
+                className="w-full mt-1 px-3 py-2 rounded-lg border border-border bg-background text-foreground"
               >
                 <option>Reunión</option>
                 <option>Examen</option>
@@ -71,31 +71,31 @@ function CreateEventModal({ onClose, onCreate, selectedDate }) {
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <Label className={darkMode ? 'text-gray-300' : ''}>Fecha *</Label>
+                <Label>Fecha *</Label>
                 <Input
                   type="date"
                   value={date}
                   onChange={(e) => setDate(e.target.value)}
-                  className={`mt-1 ${darkMode ? 'bg-gray-700 border-gray-600 text-white' : ''}`}
+                  className="mt-1 bg-background border-border text-foreground"
                 />
               </div>
               <div>
-                <Label className={darkMode ? 'text-gray-300' : ''}>Hora</Label>
+                <Label>Hora</Label>
                 <Input
                   type="time"
                   value={time}
                   onChange={(e) => setTime(e.target.value)}
-                  className={`mt-1 ${darkMode ? 'bg-gray-700 border-gray-600 text-white' : ''}`}
+                  className="mt-1 bg-background border-border text-foreground"
                 />
               </div>
             </div>
             <div>
-              <Label className={darkMode ? 'text-gray-300' : ''}>Descripción</Label>
+              <Label>Descripción</Label>
               <Textarea
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Describe tu evento..."
-                className={`mt-1 ${darkMode ? 'bg-gray-700 border-gray-600 text-white' : ''}`}
+                className="mt-1 bg-background border-border text-foreground"
                 rows={3}
               />
             </div>
@@ -243,12 +243,10 @@ export default function CalendarPage() {
           <div key={index} className={`p-4 border-2 rounded-xl ${
             day.toDateString() === selectedDate.toDateString()
               ? 'ring-2 ring-green-500 bg-green-50 border-green-200'
-              : darkMode
-                ? 'border-gray-700 bg-gray-750'
-                : 'border-gray-200'
+              : 'border-border bg-card'
           }`}>
-            <div className={`text-center mb-2 ${darkMode ? 'text-white' : 'text-gray-900'}`}>
-              <div className="text-xs font-medium text-gray-500">
+            <div className="text-center mb-2 text-foreground">
+              <div className="text-xs font-medium text-muted-foreground">
                 {day.toLocaleDateString('es-ES', { weekday: 'short' })}
               </div>
               <div className={`text-2xl font-bold ${
@@ -280,8 +278,8 @@ export default function CalendarPage() {
     // const dayTasks = getTasksForDate(selectedDate) // Unused variable
 
     return (
-      <div className={`${darkMode ? 'bg-gray-800' : 'bg-white'} rounded-xl p-6`}>
-        <h3 className={`text-xl font-bold mb-4 ${darkMode ? 'text-white' : 'text-gray-900'}`}>
+      <div className="bg-card rounded-xl p-6 border border-border">
+        <h3 className="text-xl font-bold mb-4 text-foreground">
           {selectedDate.toLocaleDateString('es-ES', {
             weekday: 'long',
             day: 'numeric',
@@ -291,8 +289,8 @@ export default function CalendarPage() {
         </h3>
         <div className="space-y-2">
           {hours.map((hour) => (
-            <div key={hour} className={`flex border-b ${darkMode ? 'border-gray-700' : 'border-gray-100'} py-2`}>
-              <div className={`w-20 text-sm font-medium ${darkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+            <div key={hour} className="flex border-b border-border py-2">
+              <div className="w-20 text-sm font-medium text-muted-foreground">
                 {hour.toString().padStart(2, '0')}:00
               </div>
               <div className="flex-1">
@@ -312,15 +310,13 @@ export default function CalendarPage() {
 
   return (
     <div className="p-6 space-y-6">
-      <div className={`rounded-xl shadow-sm p-6 mb-6 animate-in slide-in-from-top duration-300 ${
-        darkMode ? 'bg-gray-800' : 'bg-white'
-      }`}>
+      <div className="rounded-xl shadow-sm p-6 mb-6 animate-in slide-in-from-top duration-300 bg-card border border-border">
         <div className="flex items-center justify-between mb-4">
           <div>
-            <h1 className={`text-2xl font-bold ${darkMode ? 'text-white' : 'text-gray-900'}`}>
+            <h1 className="text-2xl font-bold text-foreground">
               Calendario
             </h1>
-            <p className={`mt-1 ${darkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+            <p className="mt-1 text-muted-foreground">
               Organiza tus eventos y tareas
             </p>
           </div>
@@ -341,9 +337,7 @@ export default function CalendarPage() {
               className={`px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 hover:scale-105 active:scale-95 ${
                 view === v
                   ? 'bg-green-50 text-green-600 shadow-sm'
-                  : darkMode
-                    ? 'text-gray-400 hover:bg-gray-700'
-                    : 'text-gray-600 hover:bg-gray-50'
+                  : 'text-muted-foreground hover:bg-muted'
               }`}
             >
               {v === 'month' ? 'Mes' : 'Semana'}
@@ -353,30 +347,24 @@ export default function CalendarPage() {
       </div>
 
       {view === 'month' && (
-        <div className={`rounded-xl shadow-sm p-6 mb-6 animate-in fade-in duration-500 ${
-          darkMode ? 'bg-gray-800' : 'bg-white'
-        }`}>
+        <div className="rounded-xl shadow-sm p-6 mb-6 animate-in fade-in duration-500 bg-card border border-border">
           <div className="flex items-center justify-between mb-6">
             <button
               onClick={() => navigateMonth(-1)}
-              className={`p-2 rounded-lg transition-colors ${
-                darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
-              }`}
+              className="p-2 rounded-lg transition-colors hover:bg-muted"
             >
-              <ChevronLeft className="w-5 h-5" />
+              <ChevronLeft className="w-5 h-5 text-foreground" />
             </button>
 
-            <h2 className={`text-2xl font-bold ${darkMode ? 'text-white' : 'text-gray-900'}`}>
+            <h2 className="text-2xl font-bold text-foreground">
               {monthNames[currentDate.getMonth()]} {currentDate.getFullYear()}
             </h2>
 
             <button
               onClick={() => navigateMonth(1)}
-              className={`p-2 rounded-lg transition-colors ${
-                darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
-              }`}
+              className="p-2 rounded-lg transition-colors hover:bg-muted"
             >
-              <ChevronRight className="w-5 h-5" />
+              <ChevronRight className="w-5 h-5 text-foreground" />
             </button>
           </div>
 
@@ -384,9 +372,7 @@ export default function CalendarPage() {
             {dayNames.map((day) => (
               <div
                 key={day}
-                className={`p-3 text-center font-semibold rounded-lg ${
-                  darkMode ? 'bg-gray-750 text-gray-400' : 'bg-gray-50 text-gray-600'
-                }`}
+                className="p-3 text-center font-semibold rounded-lg bg-muted text-muted-foreground"
               >
                 {day}
               </div>
@@ -401,9 +387,7 @@ export default function CalendarPage() {
                   date && date.toDateString() === selectedDate.toDateString()
                     ? 'ring-2 ring-green-500 bg-green-50 border-green-200'
                     : date
-                      ? darkMode
-                        ? 'border-gray-700 hover:border-green-500 bg-gray-750'
-                        : 'border-gray-200 hover:border-green-200'
+                      ? 'border-border hover:border-green-200 bg-card'
                       : 'border-transparent'
                 }`}
                 onClick={() => date && handleDayClick(date)}
@@ -414,9 +398,7 @@ export default function CalendarPage() {
                       className={`text-sm font-semibold mb-2 ${
                         date.toDateString() === new Date().toDateString()
                           ? 'w-7 h-7 bg-green-600 text-white rounded-full flex items-center justify-center'
-                          : darkMode
-                            ? 'text-white'
-                            : 'text-gray-900'
+                          : 'text-foreground'
                       }`}
                     >
                       {date.getDate()}
@@ -436,7 +418,7 @@ export default function CalendarPage() {
                           </div>
                         ))}
                       {getTasksForDate(date).length > 2 && (
-                        <div className="text-xs text-gray-500 font-medium">+{getTasksForDate(date).length - 2} más</div>
+                        <div className="text-xs text-muted-foreground font-medium">+{getTasksForDate(date).length - 2} más</div>
                       )}
                     </div>
                   </>
@@ -448,9 +430,7 @@ export default function CalendarPage() {
       )}
 
       {view === 'week' && (
-        <div className={`rounded-xl shadow-sm p-6 mb-6 ${
-          darkMode ? 'bg-gray-800' : 'bg-white'
-        }`}>
+        <div className="rounded-xl shadow-sm p-6 mb-6 bg-card border border-border">
           <div className="flex items-center justify-between mb-6">
             <button
               onClick={() => {
@@ -475,11 +455,9 @@ export default function CalendarPage() {
                 newDate.setDate(newDate.getDate() + 7)
                 setCurrentDate(newDate)
               }}
-              className={`p-2 rounded-lg transition-colors ${
-                darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
-              }`}
+              className="p-2 rounded-lg transition-colors hover:bg-muted"
             >
-              <ChevronRight className="w-5 h-5" />
+              <ChevronRight className="w-5 h-5 text-foreground" />
             </button>
           </div>
           {renderWeekView()}
@@ -489,24 +467,20 @@ export default function CalendarPage() {
       {view === 'day' && renderDayView()}
 
       {selectedDate && (
-        <div className={`rounded-xl shadow-sm p-6 ${
-          darkMode ? 'bg-gray-800' : 'bg-white'
-        }`}>
+        <div className="rounded-xl shadow-sm p-6 bg-card border border-border">
           <div className="flex items-center space-x-3 mb-4">
-            <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${
-              darkMode ? 'bg-green-900/30' : 'bg-green-50'
-            }`}>
-              <Clock className={`w-6 h-6 text-green-600`} />
+            <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-green-50">
+              <Clock className="w-6 h-6 text-green-600" />
             </div>
             <div>
-              <h3 className={`text-xl font-bold ${darkMode ? 'text-white' : 'text-gray-900'}`}>
+              <h3 className="text-xl font-bold text-foreground">
                 {selectedDate.toLocaleDateString('es-ES', {
                   weekday: 'long',
                   day: 'numeric',
                   month: 'long',
                 })}
               </h3>
-              <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+              <p className="text-sm text-muted-foreground">
                 {getTasksForDate(selectedDate).length} eventos programados
               </p>
             </div>
@@ -515,10 +489,8 @@ export default function CalendarPage() {
           <div className="space-y-3">
             {getTasksForDate(selectedDate).length === 0 ? (
               <div className="text-center py-12">
-                <Calendar className={`w-12 h-12 mx-auto mb-3 ${
-                  darkMode ? 'text-gray-600' : 'text-gray-300'
-                }`} />
-                <p className={darkMode ? 'text-gray-400' : 'text-gray-500'}>
+                <Calendar className="w-12 h-12 mx-auto mb-3 text-muted-foreground" />
+                <p className="text-muted-foreground">
                   No hay eventos para este día
                 </p>
                 <button className="mt-4 text-green-600 hover:text-green-700 font-medium text-sm">

--- a/frontend/src/features/dashboard/components/HomePage.jsx
+++ b/frontend/src/features/dashboard/components/HomePage.jsx
@@ -72,8 +72,6 @@ const HomePage = () => {
   const [userName, setUserName] = useState('')
   const navigate = useNavigate()
   const { user } = useAuth()
-  // Mock darkMode, in real app use context
-  const darkMode = false
   const unreadCount = 3
 
   useEffect(() => {
@@ -84,16 +82,14 @@ const HomePage = () => {
   }, [user])
 
   return (
-    <div className={`p-8 ${darkMode ? 'bg-gray-900' : ''}`}>
-      <header className={`sticky top-0 rounded-xl shadow-sm p-6 mb-6 z-10 animate-in slide-in-from-top duration-300 ${
-        darkMode ? 'bg-gray-800' : 'bg-white'
-      }`}>
+    <div className="p-8 bg-background">
+      <header className="sticky top-0 rounded-xl shadow-sm p-6 mb-6 z-10 animate-in slide-in-from-top duration-300 bg-card">
         <div className="flex justify-between items-center">
           <div>
-            <h1 className={`text-2xl font-bold ${darkMode ? 'text-white' : 'text-gray-900'}`}>
+            <h1 className="text-2xl font-bold text-foreground">
               👋 Bienvenid@ {userName ? userName : 'Estudiante'}
             </h1>
-            <p className={`${darkMode ? 'text-gray-400' : 'text-gray-600'} mt-1`}>
+            <p className="text-muted-foreground mt-1">
               {getCurrentDate()}
             </p>
           </div>
@@ -125,17 +121,13 @@ const HomePage = () => {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-3 space-y-6">
-          <Card className={`p-6 rounded-xl shadow-sm animate-in fade-in slide-in-from-bottom duration-500 ${
-            darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white'
-          }`}>
+          <Card className="p-6 rounded-xl shadow-sm animate-in fade-in slide-in-from-bottom duration-500 bg-card">
             <div className="flex justify-between items-center mb-4">
-              <h2 className={`text-xl font-semibold ${darkMode ? 'text-white' : 'text-gray-900'}`}>
+              <h2 className="text-xl font-semibold text-foreground">
                 Tareas Pendientes
               </h2>
               <Link to="/tasks">
-                <Button variant="ghost" className={`text-green-600 hover:text-green-700 hover:bg-green-50 transition-all duration-200 hover:scale-105 ${
-                  darkMode ? 'text-green-400 hover:text-green-500 hover:bg-green-400' : ''
-                }`}>
+                <Button variant="ghost" className="text-green-600 hover:text-green-700 hover:bg-green-50 transition-all duration-200 hover:scale-105 dark:hover:bg-green-900/20">
                   Ver todas
                 </Button>
               </Link>
@@ -144,20 +136,18 @@ const HomePage = () => {
               {mockTasks.map((task, index) => (
                 <div
                   key={task.id}
-                  className={`p-4 border rounded-lg transition-all duration-200 cursor-pointer animate-in fade-in slide-in-from-left hover:scale-[1.02] hover:shadow-md ${
-                    darkMode ? 'border-gray-700 bg-gray-750 hover:border-green-600' : 'border-gray-200 hover:border-green-500'
-                  }`}
+                  className="p-4 border rounded-lg transition-all duration-200 cursor-pointer animate-in fade-in slide-in-from-left hover:scale-[1.02] hover:shadow-md border-border hover:border-green-500 bg-card"
                   style={{ animationDelay: `${index * 100}ms` }}
                   onClick={() => navigate(`/tasks/${task.id}`)}
                 >
                   <div className="flex items-center gap-3 mb-1">
-                    <h3 className={`text-base font-semibold ${darkMode ? 'text-white' : 'text-gray-900'}`}>
+                    <h3 className="text-base font-semibold text-foreground">
                       {task.title}
                     </h3>
                     <span className="text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-800">{task.priority}</span>
                     <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-800">{task.status}</span>
                   </div>
-                  <div className={`flex items-center gap-4 text-sm ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                  <div className="flex items-center gap-4 text-sm text-muted-foreground">
                     <div className="flex items-center">
                       <CalendarIcon size={14} className="mr-1.5 text-green-600" />
                       {new Date(task.dueDate).toLocaleDateString('es-ES', {
@@ -176,11 +166,9 @@ const HomePage = () => {
             </div>
           </Card>
 
-          <Card className={`p-6 rounded-xl shadow-sm animate-in fade-in slide-in-from-bottom duration-500 delay-200 ${
-            darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white'
-          }`}>
+          <Card className="p-6 rounded-xl shadow-sm animate-in fade-in slide-in-from-bottom duration-500 delay-200 bg-card">
             <div className="flex justify-between items-center mb-4">
-              <h2 className={`text-xl font-semibold ${darkMode ? 'text-white' : 'text-gray-900'}`}>
+              <h2 className="text-xl font-semibold text-foreground">
                 Resumen General
               </h2>
             </div>

--- a/frontend/src/features/notes/NotesPage.jsx
+++ b/frontend/src/features/notes/NotesPage.jsx
@@ -68,7 +68,7 @@ function NoteDetailModal({ note, onClose, onSave, onDelete, onTogglePin }) {
 
   return (
     <div className="fixed inset-0 bg-black/30 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[85vh] overflow-y-auto">
+      <div className="bg-card rounded-xl shadow-2xl w-full max-w-2xl max-h-[85vh] overflow-y-auto border border-border">
         <div className="p-6">
           <div className="flex justify-between items-start mb-6">
             <div className="flex items-center gap-3">
@@ -76,8 +76,8 @@ function NoteDetailModal({ note, onClose, onSave, onDelete, onTogglePin }) {
                 <FileText size={24} className="text-gray-700" />
               </div>
               <div>
-                <h2 className="text-xl font-bold text-gray-900">Detalle de Nota</h2>
-                <p className="text-sm text-gray-500">
+                <h2 className="text-xl font-bold text-foreground">Detalle de Nota</h2>
+                <p className="text-sm text-muted-foreground">
                   Editado: {note.lastEdited.includes('-') ?
                     new Date(note.lastEdited).toLocaleDateString('es-ES', { day: 'numeric', month: 'short' })
                     : note.lastEdited}
@@ -96,7 +96,7 @@ function NoteDetailModal({ note, onClose, onSave, onDelete, onTogglePin }) {
                 <Input
                   value={editedTitle}
                   onChange={(e) => setEditedTitle(e.target.value)}
-                  className="mt-1"
+                  className="mt-1 bg-background border-border text-foreground"
                 />
               </div>
               <div>
@@ -104,7 +104,7 @@ function NoteDetailModal({ note, onClose, onSave, onDelete, onTogglePin }) {
                 <Input
                   value={editedSubject}
                   onChange={(e) => setEditedSubject(e.target.value)}
-                  className="mt-1"
+                  className="mt-1 bg-background border-border text-foreground"
                   placeholder="Opcional"
                 />
               </div>
@@ -113,7 +113,7 @@ function NoteDetailModal({ note, onClose, onSave, onDelete, onTogglePin }) {
                 <Textarea
                   value={editedContent}
                   onChange={(e) => setEditedContent(e.target.value)}
-                  className="mt-1 min-h-[300px]"
+                  className="mt-1 min-h-[300px] bg-background border-border text-foreground"
                 />
               </div>
               <div className="flex gap-2 justify-end pt-4">
@@ -129,16 +129,16 @@ function NoteDetailModal({ note, onClose, onSave, onDelete, onTogglePin }) {
           ) : (
             <>
               <div className="mb-4">
-                <h3 className="text-2xl font-bold text-gray-900 mb-2">{note.title}</h3>
+                <h3 className="text-2xl font-bold text-foreground mb-2">{note.title}</h3>
                 {note.subject && (
-                  <span className="inline-block text-sm font-medium text-gray-700 bg-gray-100 px-3 py-1 rounded-md">
+                  <span className="inline-block text-sm font-medium text-card-foreground bg-muted px-3 py-1 rounded-md">
                     {note.subject}
                   </span>
                 )}
               </div>
 
               <div className="prose max-w-none mb-6">
-                <p className="text-gray-700 whitespace-pre-wrap leading-relaxed">{note.content}</p>
+                <p className="text-muted-foreground whitespace-pre-wrap leading-relaxed">{note.content}</p>
               </div>
 
               <div className="flex gap-2 pt-4 border-t">
@@ -187,7 +187,7 @@ function CreateNoteModal({ onClose, onCreate }) {
 
   return (
     <div className="fixed inset-0 bg-black/30 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[85vh] overflow-y-auto">
+      <div className="bg-card rounded-xl shadow-2xl w-full max-w-2xl max-h-[85vh] overflow-y-auto border border-border">
         <div className="p-6">
           <div className="flex justify-between items-start mb-6">
             <div className="flex items-center gap-3">
@@ -195,8 +195,8 @@ function CreateNoteModal({ onClose, onCreate }) {
                 <Plus size={24} className="text-green-600" />
               </div>
               <div>
-                <h2 className="text-xl font-bold text-gray-900">Nueva Nota</h2>
-                <p className="text-sm text-gray-500">Crea una nueva nota para tus estudios</p>
+                <h2 className="text-xl font-bold text-foreground">Nueva Nota</h2>
+                <p className="text-sm text-muted-foreground">Crea una nueva nota para tus estudios</p>
               </div>
             </div>
             <Button variant="ghost" size="icon" onClick={onClose}>
@@ -211,7 +211,7 @@ function CreateNoteModal({ onClose, onCreate }) {
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="Título de la nota"
-                className="mt-1"
+                className="mt-1 bg-background border-border text-foreground"
               />
             </div>
             <div>
@@ -220,7 +220,7 @@ function CreateNoteModal({ onClose, onCreate }) {
                 value={subject}
                 onChange={(e) => setSubject(e.target.value)}
                 placeholder="Opcional"
-                className="mt-1"
+                className="mt-1 bg-background border-border text-foreground"
               />
             </div>
             <div className="flex items-center space-x-2">
@@ -237,7 +237,7 @@ function CreateNoteModal({ onClose, onCreate }) {
                 value={content}
                 onChange={(e) => setContent(e.target.value)}
                 placeholder="Escribe el contenido de tu nota aquí..."
-                className="mt-1 min-h-[300px]"
+                className="mt-1 min-h-[300px] bg-background border-border text-foreground"
               />
             </div>
             <div className="flex gap-2 justify-end pt-4">
@@ -292,7 +292,7 @@ function NoteCard({ note, index, onClick, onTogglePin }) {
             </Badge>
           ) : (<div></div>)}
         </div>
-        <p className="text-xs text-gray-400 mt-2">
+        <p className="text-xs text-gray-500 mt-2">
           Editado:{' '}
           {note.lastEdited.includes('-') ?
             new Date(note.lastEdited).toLocaleDateString('es-ES', { day: 'numeric', month: 'short' })
@@ -458,14 +458,14 @@ export default function NotesPage() {
   }
 
   return (
-    <div className="min-h-screen bg-[#F6F7FB]">
+    <div className="min-h-screen bg-background">
       <div className="max-w-7xl mx-auto p-8">
         {/* Header */}
-        <header className="sticky top-0 bg-white rounded-xl shadow-sm p-6 mb-6 z-10">
+        <header className="sticky top-0 bg-card rounded-xl shadow-sm p-6 mb-6 z-10 border border-border">
           <div className="flex justify-between items-center">
             <div>
-              <h1 className="text-2xl font-bold text-gray-900">📝 Mis Notas</h1>
-              <p className="text-gray-600 mt-1">{getCurrentDate()}</p>
+              <h1 className="text-2xl font-bold text-foreground">📝 Mis Notas</h1>
+              <p className="text-muted-foreground mt-1">{getCurrentDate()}</p>
             </div>
             <div className="flex items-center space-x-4">
               <Button className="bg-green-600 hover:bg-green-700" onClick={() => setShowCreateModal(true)}>
@@ -479,12 +479,12 @@ export default function NotesPage() {
         {/* Search */}
         <div className="mb-6">
           <div className="relative">
-            <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+            <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={18} />
             <Input
               placeholder="Buscar notas..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-10 bg-white"
+              className="pl-10 bg-card border-border text-foreground"
             />
           </div>
         </div>
@@ -492,7 +492,7 @@ export default function NotesPage() {
         {/* Pinned Notes */}
         {filteredPinnedNotes.length > 0 && (
           <div className="mb-8">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center">
+            <h2 className="text-lg font-semibold text-foreground mb-4 flex items-center">
               <Pin size={18} className="mr-2 text-green-600" />
               Notas Fijadas
             </h2>
@@ -506,11 +506,11 @@ export default function NotesPage() {
 
         {/* Regular Notes */}
         <div>
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">Todas las Notas</h2>
+          <h2 className="text-lg font-semibold text-foreground mb-4">Todas las Notas</h2>
           <AnimatePresence>
             {regularNotes.length === 0 && filteredPinnedNotes.length === 0 ? (
-              <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-center py-12 bg-white rounded-xl">
-                <p className="text-gray-500">No se encontraron notas</p>
+              <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-center py-12 bg-card rounded-xl border border-border">
+                <p className="text-muted-foreground">No se encontraron notas</p>
               </motion.div>
             ) : (
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -537,7 +537,7 @@ export default function NotesPage() {
 
       {showDeleteConfirm && (
         <div className="fixed inset-0 bg-black/30 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[85vh] overflow-y-auto">
+          <div className="bg-card rounded-xl shadow-2xl w-full max-w-md max-h-[85vh] overflow-y-auto border border-border">
             <div className="p-6">
               <div className="flex justify-between items-start mb-6">
                 <div className="flex items-center gap-3">
@@ -545,8 +545,8 @@ export default function NotesPage() {
                     <Trash2 size={24} className="text-red-600" />
                   </div>
                   <div>
-                    <h2 className="text-xl font-bold text-gray-900">Eliminar Nota</h2>
-                    <p className="text-sm text-gray-500">Esta acción no se puede deshacer</p>
+                    <h2 className="text-xl font-bold text-foreground">Eliminar Nota</h2>
+                    <p className="text-sm text-muted-foreground">Esta acción no se puede deshacer</p>
                   </div>
                 </div>
                 <Button variant="ghost" size="icon" onClick={() => setShowDeleteConfirm(null)}>
@@ -554,7 +554,7 @@ export default function NotesPage() {
                 </Button>
               </div>
 
-              <p className="text-gray-700 mb-6">
+              <p className="text-muted-foreground mb-6">
                 ¿Estás seguro de que quieres eliminar esta nota? Se perderá permanentemente.
               </p>
 

--- a/frontend/src/features/profile/ProfilePage.jsx
+++ b/frontend/src/features/profile/ProfilePage.jsx
@@ -135,7 +135,7 @@ const ProfilePage = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       {/* Header */}
       <div className="bg-green-600 text-white p-6 shadow-lg">
         <div className="max-w-4xl mx-auto">
@@ -145,7 +145,7 @@ const ProfilePage = () => {
       </div>
 
       <div className="max-w-4xl mx-auto p-6">
-        <div className="bg-white rounded-lg shadow-lg overflow-hidden">
+        <div className="bg-card rounded-lg shadow-lg overflow-hidden border border-border">
           {/* Profile Header */}
           <div className="bg-gradient-to-r from-green-500 to-green-600 p-8 text-white">
             <div className="flex items-center space-x-6">
@@ -168,11 +168,11 @@ const ProfilePage = () => {
           {/* Profile Content */}
           <div className="p-8">
             <div className="flex justify-between items-center mb-6">
-              <h3 className="text-xl font-semibold text-gray-900">Información Personal</h3>
+              <h3 className="text-xl font-semibold text-foreground">Información Personal</h3>
               {!isEditing ? (
                 <button
                   onClick={() => setIsEditing(true)}
-                  className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+                  className="inline-flex items-center px-4 py-2 border border-border rounded-md shadow-sm text-sm font-medium text-foreground bg-card hover:bg-muted focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
                 >
                   <Edit3 className="h-4 w-4 mr-2" />
                   Editar
@@ -189,7 +189,7 @@ const ProfilePage = () => {
                   </button>
                   <button
                     onClick={handleCancel}
-                    className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+                    className="inline-flex items-center px-4 py-2 border border-border rounded-md shadow-sm text-sm font-medium text-foreground bg-card hover:bg-muted focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
                   >
                     <X className="h-4 w-4 mr-2" />
                     Cancelar
@@ -201,7 +201,7 @@ const ProfilePage = () => {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {/* First Name Field */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-foreground mb-2">
                   Nombre
                 </label>
                 {isEditing ? (
@@ -209,19 +209,19 @@ const ProfilePage = () => {
                     type="text"
                     value={formData.firstName}
                     onChange={(e) => handleInputChange('firstName', e.target.value)}
-                    className="w-full"
+                    className="w-full bg-background border-border text-foreground"
                   />
                 ) : (
-                  <div className="flex items-center space-x-2 p-3 bg-gray-50 rounded-md">
-                    <User className="h-5 w-5 text-gray-400" />
-                    <span className="text-gray-900">{user.firstName}</span>
+                  <div className="flex items-center space-x-2 p-3 bg-muted rounded-md">
+                    <User className="h-5 w-5 text-muted-foreground" />
+                    <span className="text-foreground">{user.firstName}</span>
                   </div>
                 )}
               </div>
 
               {/* Last Name Field */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-foreground mb-2">
                   Apellido
                 </label>
                 {isEditing ? (
@@ -229,19 +229,19 @@ const ProfilePage = () => {
                     type="text"
                     value={formData.lastName}
                     onChange={(e) => handleInputChange('lastName', e.target.value)}
-                    className="w-full"
+                    className="w-full bg-background border-border text-foreground"
                   />
                 ) : (
-                  <div className="flex items-center space-x-2 p-3 bg-gray-50 rounded-md">
-                    <User className="h-5 w-5 text-gray-400" />
-                    <span className="text-gray-900">{user.lastName}</span>
+                  <div className="flex items-center space-x-2 p-3 bg-muted rounded-md">
+                    <User className="h-5 w-5 text-muted-foreground" />
+                    <span className="text-foreground">{user.lastName}</span>
                   </div>
                 )}
               </div>
 
               {/* Email Field */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-foreground mb-2">
                   Correo Electrónico
                 </label>
                 {isEditing ? (
@@ -249,12 +249,12 @@ const ProfilePage = () => {
                     type="email"
                     value={formData.email}
                     onChange={(e) => handleInputChange('email', e.target.value)}
-                    className="w-full"
+                    className="w-full bg-background border-border text-foreground"
                   />
                 ) : (
-                  <div className="flex items-center space-x-2 p-3 bg-gray-50 rounded-md">
-                    <Mail className="h-5 w-5 text-gray-400" />
-                    <span className="text-gray-900">{user.email}</span>
+                  <div className="flex items-center space-x-2 p-3 bg-muted rounded-md">
+                    <Mail className="h-5 w-5 text-muted-foreground" />
+                    <span className="text-foreground">{user.email}</span>
                   </div>
                 )}
               </div>
@@ -262,7 +262,7 @@ const ProfilePage = () => {
 
               {/* Career Field */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-foreground mb-2">
                   Carrera
                 </label>
                 {isEditing ? (
@@ -271,19 +271,19 @@ const ProfilePage = () => {
                     value={formData.career}
                     onChange={(e) => handleInputChange('career', e.target.value)}
                     placeholder="Ej: Ingeniería de Sistemas"
-                    className="w-full"
+                    className="w-full bg-background border-border text-foreground"
                   />
                 ) : (
-                  <div className="flex items-center space-x-2 p-3 bg-gray-50 rounded-md">
-                    <User className="h-5 w-5 text-gray-400" />
-                    <span className="text-gray-900">{user.carrer || 'No especificada'}</span>
+                  <div className="flex items-center space-x-2 p-3 bg-muted rounded-md">
+                    <User className="h-5 w-5 text-muted-foreground" />
+                    <span className="text-foreground">{user.carrer || 'No especificada'}</span>
                   </div>
                 )}
               </div>
 
               {/* Bio Field - Full Width */}
               <div className="md:col-span-2">
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-foreground mb-2">
                   Biografía
                 </label>
                 {isEditing ? (
@@ -291,24 +291,24 @@ const ProfilePage = () => {
                     value={formData.bio}
                     onChange={(e) => handleInputChange('bio', e.target.value)}
                     placeholder="Cuéntanos un poco sobre ti..."
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 resize-none"
+                    className="w-full px-3 py-2 border border-border bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 resize-none"
                     rows={3}
                   />
                 ) : (
-                  <div className="p-3 bg-gray-50 rounded-md">
-                    <span className="text-gray-900">{user.bio || 'Sin biografía'}</span>
+                  <div className="p-3 bg-muted rounded-md">
+                    <span className="text-foreground">{user.bio || 'Sin biografía'}</span>
                   </div>
                 )}
               </div>
 
               {/* Registration Date */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
+                <label className="block text-sm font-medium text-foreground mb-2">
                   Fecha de Registro
                 </label>
-                <div className="flex items-center space-x-2 p-3 bg-gray-50 rounded-md">
-                  <Calendar className="h-5 w-5 text-gray-400" />
-                  <span className="text-gray-900">
+                <div className="flex items-center space-x-2 p-3 bg-muted rounded-md">
+                  <Calendar className="h-5 w-5 text-muted-foreground" />
+                  <span className="text-foreground">
                     {new Date(user.created_at).toLocaleDateString('es-ES', {
                       year: 'numeric',
                       month: 'long',
@@ -320,8 +320,8 @@ const ProfilePage = () => {
             </div>
 
             {/* Account Statistics */}
-            <div className="mt-8 pt-6 border-t border-gray-200">
-              <h3 className="text-xl font-semibold text-gray-900 mb-4">Estadísticas de Cuenta</h3>
+            <div className="mt-8 pt-6 border-t border-border">
+              <h3 className="text-xl font-semibold text-foreground mb-4">Estadísticas de Cuenta</h3>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div className="bg-green-50 p-4 rounded-lg">
                   <div className="text-2xl font-bold text-green-600">0</div>

--- a/frontend/src/features/settings/SettingsPage.jsx
+++ b/frontend/src/features/settings/SettingsPage.jsx
@@ -389,9 +389,9 @@ export default function SettingsPage() {
 
 
   return (
-    <div className={`${darkMode ? 'bg-gray-900' : 'bg-[#F6F7FB]'}`}>
+    <div className={`${darkMode ? 'bg-background' : 'bg-[#F6F7FB]'}`}>
       <div className={`max-w-7xl mx-auto ${compactView ? 'p-4' : 'p-8'} ${compactView ? 'pb-24' : 'pb-8'}`}>
-        <header className={`sticky top-0 ${darkMode ? 'bg-gray-800' : 'bg-white'} rounded-xl shadow-sm ${compactView ? 'p-4' : 'p-6'} mb-6 z-10 animate-in slide-in-from-top duration-300`}>
+        <header className={`sticky top-0 ${darkMode ? 'bg-card' : 'bg-white'} rounded-xl shadow-sm ${compactView ? 'p-4' : 'p-6'} mb-6 z-10 animate-in slide-in-from-top duration-300`}>
           <div className="flex justify-between items-center">
             <div>
               <h1 className={`text-2xl font-bold ${darkMode ? 'text-white' : 'text-gray-900'}`}>⚙️ Configuración</h1>
@@ -402,7 +402,7 @@ export default function SettingsPage() {
 
         <div className={`grid grid-cols-1 lg:grid-cols-3 ${compactView ? 'gap-4' : 'gap-6'}`}>
           <div className="lg:col-span-1 animate-in slide-in-from-left duration-500">
-            <Card className={`${compactView ? 'p-3' : 'p-4'} ${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white'} rounded-xl shadow-sm`}>
+            <Card className={`${compactView ? 'p-3' : 'p-4'} ${darkMode ? 'bg-card border-gray-700' : 'bg-white'} rounded-xl shadow-sm`}>
               <nav className={compactView ? 'space-y-1' : 'space-y-2'}>
                 <SettingsMenuItem
                   icon={<User size={18} />}
@@ -436,7 +436,7 @@ export default function SettingsPage() {
 
             {/* PERFIL SECTION */}
             {activeSection === 'perfil' && (
-              <Card className={`${compactView ? 'p-4' : 'p-6'} ${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white'} rounded-xl shadow-sm`}>
+              <Card className={`${compactView ? 'p-4' : 'p-6'} ${darkMode ? 'bg-card border-gray-700' : 'bg-white'} rounded-xl shadow-sm`}>
                 <h2 className={`text-xl font-semibold ${darkMode ? 'text-white' : 'text-gray-900'} ${compactView ? 'mb-4' : 'mb-6'}`}>
                   Información Personal
                 </h2>
@@ -595,7 +595,7 @@ export default function SettingsPage() {
 
             {/* SEGURIDAD SECTION */}
             {activeSection === 'seguridad' && (
-              <Card className={`${compactView ? 'p-4' : 'p-6'} ${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white'} rounded-xl shadow-sm`}>
+              <Card className={`${compactView ? 'p-4' : 'p-6'} ${darkMode ? 'bg-card border-gray-700' : 'bg-white'} rounded-xl shadow-sm`}>
                 <h2 className={`text-xl font-semibold ${darkMode ? 'text-white' : 'text-gray-900'} ${compactView ? 'mb-4' : 'mb-6'}`}>
                   Cambiar Contraseña
                 </h2>
@@ -669,7 +669,7 @@ export default function SettingsPage() {
 
             {/* APARIENCIA SECTION */}
             {activeSection === 'apariencia' && (
-              <Card className={`${compactView ? 'p-4' : 'p-6'} ${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white'} rounded-xl shadow-sm`}>
+              <Card className={`${compactView ? 'p-4' : 'p-6'} ${darkMode ? 'bg-card border-gray-700' : 'bg-white'} rounded-xl shadow-sm`}>
                 <h2 className={`text-xl font-semibold ${darkMode ? 'text-white' : 'text-gray-900'} ${compactView ? 'mb-4' : 'mb-6'}`}>
                   Personalización de la Interfaz
                 </h2>
@@ -727,7 +727,7 @@ export default function SettingsPage() {
 
             {/* PRIVACIDAD SECTION */}
             {activeSection === 'privacidad' && (
-              <Card className={`${compactView ? 'p-4' : 'p-6'} ${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white'} rounded-xl shadow-sm`}>
+              <Card className={`${compactView ? 'p-4' : 'p-6'} ${darkMode ? 'bg-card border-gray-700' : 'bg-white'} rounded-xl shadow-sm`}>
                 <h2 className={`text-xl font-semibold ${darkMode ? 'text-white' : 'text-gray-900'} ${compactView ? 'mb-4' : 'mb-6'}`}>
                   Gestión de Datos
                 </h2>
@@ -752,7 +752,7 @@ export default function SettingsPage() {
 
             {/* Delete Account Modal */}
             <Dialog open={showDeleteModal} onOpenChange={setShowDeleteModal}>
-              <DialogContent className={`${darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white'} max-w-md`}>
+              <DialogContent className={`${darkMode ? 'bg-card border-gray-700' : 'bg-white'} max-w-md`}>
                 <DialogHeader>
                   <DialogTitle className={`text-xl font-bold ${darkMode ? 'text-red-400' : 'text-red-600'}`}>
                     ⚠️ Eliminar Cuenta

--- a/frontend/src/features/stats/StatsPage.jsx
+++ b/frontend/src/features/stats/StatsPage.jsx
@@ -125,14 +125,14 @@ export default function StatsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-[#F6F7FB]">
+    <div className="min-h-screen bg-background">
       <div className="max-w-7xl mx-auto p-8">
         {/* Header */}
-        <header className="sticky top-0 bg-white rounded-xl shadow-sm p-6 mb-6 z-10">
+        <header className="sticky top-0 bg-card rounded-xl shadow-sm p-6 mb-6 z-10 border border-border">
           <div className="flex justify-between items-center">
             <div>
-              <h1 className="text-2xl font-bold text-gray-900">📊 Mis Estadísticas</h1>
-              <p className="text-gray-600 mt-1">{getCurrentDate()}</p>
+              <h1 className="text-2xl font-bold text-foreground">📊 Mis Estadísticas</h1>
+              <p className="text-muted-foreground mt-1">{getCurrentDate()}</p>
             </div>
             <ManageSubjectsDialog
               onUpdate={fetchStats}
@@ -176,8 +176,8 @@ export default function StatsPage() {
 
         {/* Progress by Subject */}
         {stats.subjects && stats.subjects.length > 0 ? (
-          <Card className="p-6 bg-white rounded-xl shadow-sm mb-6">
-            <h2 className="text-xl font-semibold text-gray-900 mb-6">Progreso por Materia</h2>
+          <Card className="p-6 bg-card rounded-xl shadow-sm mb-6 border border-border">
+            <h2 className="text-xl font-semibold text-foreground mb-6">Progreso por Materia</h2>
             <div className="space-y-6">
               {stats.subjects.map((subject) => (
                 <SubjectProgress key={subject.id || subject.name} subject={subject} />
@@ -185,16 +185,16 @@ export default function StatsPage() {
             </div>
           </Card>
         ) : (
-           <Card className="p-6 bg-white rounded-xl shadow-sm mb-6">
-              <h2 className="text-xl font-semibold text-gray-900 mb-2">Materias</h2>
-              <p className="text-gray-500">No hay materias registradas aún. ¡Agrega algunas para ver tu progreso académico!</p>
+           <Card className="p-6 bg-card rounded-xl shadow-sm mb-6 border border-border">
+              <h2 className="text-xl font-semibold text-foreground mb-2">Materias</h2>
+              <p className="text-muted-foreground">No hay materias registradas aún. ¡Agrega algunas para ver tu progreso académico!</p>
            </Card>
         )}
 
         {/* Charts mock (no external libs) */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <Card className="p-6 bg-white rounded-xl shadow-sm">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">Completación de Tareas</h2>
+          <Card className="p-6 bg-card rounded-xl shadow-sm border border-border">
+            <h2 className="text-xl font-semibold text-foreground mb-4">Completación de Tareas</h2>
             <div className="flex items-center justify-center h-64">
               <div className="relative w-48 h-48">
                 <svg className="transform -rotate-90 w-48 h-48">
@@ -211,15 +211,15 @@ export default function StatsPage() {
                   />
                 </svg>
                 <div className="absolute inset-0 flex items-center justify-center flex-col">
-                  <span className="text-4xl font-bold text-gray-900">{completionPercent}%</span>
-                  <span className="text-sm text-gray-500">Completado</span>
+                  <span className="text-4xl font-bold text-foreground">{completionPercent}%</span>
+                  <span className="text-sm text-muted-foreground">Completado</span>
                 </div>
               </div>
             </div>
           </Card>
 
-          <Card className="p-6 bg-white rounded-xl shadow-sm">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">Rendimiento Mensual</h2>
+          <Card className="p-6 bg-card rounded-xl shadow-sm border border-border">
+            <h2 className="text-xl font-semibold text-foreground mb-4">Rendimiento Mensual</h2>
             <div className="space-y-4">
               {/* Mock data for monthly performance as backend doesn't support this granularity yet */}
               <MonthBar month="Septiembre" color="bg-blue-600" value={75} label="7.5" />

--- a/frontend/src/features/tasks/TaskPage.jsx
+++ b/frontend/src/features/tasks/TaskPage.jsx
@@ -152,15 +152,15 @@ const TaskPage = () => {
   }
 
   return (
-    <div className="p-8">
+    <div className="p-8 bg-background">
       {/* Header */}
-      <header className="sticky top-0 bg-white rounded-xl shadow-sm p-6 mb-6 z-10">
+      <header className="sticky top-0 bg-card rounded-xl shadow-sm p-6 mb-6 z-10">
         <div className="flex justify-between items-center">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">
+            <h1 className="text-2xl font-bold text-foreground">
               {activeTab === 'tasks' ? 'Mis Tareas' : 'Categorías'}
             </h1>
-            <p className="text-gray-600 mt-1">
+            <p className="text-muted-foreground mt-1">
               {activeTab === 'tasks'
                 ? 'Gestiona tus tareas y mantén tu racha de productividad'
                 : 'Organiza tus tareas con categorías personalizadas'
@@ -179,7 +179,7 @@ const TaskPage = () => {
           </div>
 
           {/* Actions Bar */}
-          <Card className="p-6 bg-white rounded-xl shadow-sm mb-6">
+          <Card className="p-6 bg-card rounded-xl shadow-sm mb-6">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-4">
                 <Button onClick={() => setShowTaskForm(true)} className="bg-green-600 hover:bg-green-700">
@@ -188,15 +188,15 @@ const TaskPage = () => {
                 </Button>
                 <Button
                   variant="outline"
-                  className="border-gray-300 bg-white"
+                  className="border-input bg-background"
                   onClick={() => setShowFilters((v) => !v)}
                   title="Filtros"
                 >
-                  <Filter size={18} className="mr-2 text-gray-500" />
+                  <Filter size={18} className="mr-2 text-muted-foreground" />
                   Filtros
                 </Button>
               </div>
-              <div className="text-sm text-gray-500">
+              <div className="text-sm text-muted-foreground">
                 {filteredTasks.length} de {tasks.length} tareas
               </div>
             </div>
@@ -204,28 +204,28 @@ const TaskPage = () => {
             {/* Search */}
             <div className="mt-4">
               <div className="relative">
-                <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+                <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={18} />
                 <Input
                   placeholder="Buscar tareas..."
                   value={filters.searchText}
                   onChange={(e) => handleFilterChange('searchText', e.target.value)}
-                  className="pl-10 bg-white"
+                  className="pl-10 bg-background"
                 />
               </div>
             </div>
 
             {/* Advanced Filters */}
             {showFilters && (
-              <div className="mt-4 pt-4 border-t border-gray-200">
+              <div className="mt-4 pt-4 border-t border-border">
                 <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-muted-foreground mb-1">
                       Categoría
                     </label>
                     <select
                       value={filters.categoryId}
                       onChange={(e) => handleFilterChange('categoryId', e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-green-500 focus:border-green-500 bg-white"
+                      className="w-full px-3 py-2 border border-input rounded-lg focus:ring-green-500 focus:border-green-500 bg-background text-foreground"
                     >
                       <option value="">Todas las categorías</option>
                       {categories.map((category) => (
@@ -237,13 +237,13 @@ const TaskPage = () => {
                   </div>
 
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-muted-foreground mb-1">
                       Prioridad
                     </label>
                     <select
                       value={filters.priorityId}
                       onChange={(e) => handleFilterChange('priorityId', e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-green-500 focus:border-green-500 bg-white"
+                      className="w-full px-3 py-2 border border-input rounded-lg focus:ring-green-500 focus:border-green-500 bg-background text-foreground"
                     >
                       <option value="">Todas las prioridades</option>
                       {priorities.map((priority) => (
@@ -255,13 +255,13 @@ const TaskPage = () => {
                   </div>
 
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-muted-foreground mb-1">
                       Estado
                     </label>
                     <select
                       value={filters.completed}
                       onChange={(e) => handleFilterChange('completed', e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-green-500 focus:border-green-500 bg-white"
+                      className="w-full px-3 py-2 border border-input rounded-lg focus:ring-green-500 focus:border-green-500 bg-background text-foreground"
                     >
                       <option value="">Todos</option>
                       <option value="false">Pendientes</option>
@@ -270,7 +270,7 @@ const TaskPage = () => {
                   </div>
 
                   <div className="flex md:items-end">
-                    <Button variant="ghost" onClick={clearFilters} className="text-gray-700">
+                    <Button variant="ghost" onClick={clearFilters} className="text-muted-foreground">
                       Limpiar filtros
                     </Button>
                   </div>
@@ -303,16 +303,16 @@ const TaskPage = () => {
 
       {/* Main Tabs */}
       <Tabs defaultValue={activeTab} className="w-full">
-        <TabsList className="task-main-tabs bg-white mb-6 rounded-xl p-1 shadow-sm">
+        <TabsList className="task-main-tabs bg-card mb-6 rounded-xl p-1 shadow-sm">
           <TabsTrigger
             value="tasks"
-            className="tab-trigger px-6 py-2.5 rounded-lg font-medium"
+            className="tab-trigger px-6 py-2.5 rounded-lg font-medium data-[state=active]:bg-background data-[state=active]:text-foreground"
           >
             <span className="tab-icon">📝</span> Mis Tareas
           </TabsTrigger>
           <TabsTrigger
             value="categories"
-            className="tab-trigger px-6 py-2.5 rounded-lg font-medium"
+            className="tab-trigger px-6 py-2.5 rounded-lg font-medium data-[state=active]:bg-background data-[state=active]:text-foreground"
           >
             <span className="tab-icon">🏷️</span> Categorías
           </TabsTrigger>
@@ -322,7 +322,7 @@ const TaskPage = () => {
         <TabsContent value="tasks" className="tab-content space-y-6">
           {/* Sub-tabs for task status */}
           <Tabs defaultValue="todas" className="w-full">
-            <TabsList className="task-sub-tabs bg-gray-50 mb-4 rounded-lg p-1">
+            <TabsList className="task-sub-tabs bg-muted mb-4 rounded-lg p-1">
               <TabsTrigger
                 value="todas"
                 className="tab-trigger px-4 py-2 rounded-md text-sm font-medium"
@@ -352,11 +352,11 @@ const TaskPage = () => {
             <TabsContent value="todas">
               <div className="space-y-4">
                 {filteredTasks.length === 0 ? (
-                  <Card className="p-12 text-center bg-white rounded-xl shadow-sm">
-                    <div className="text-gray-500 text-lg mb-2">
+                  <Card className="p-12 text-center bg-card rounded-xl shadow-sm">
+                    <div className="text-muted-foreground text-lg mb-2">
                       {tasks.length === 0 ? 'No tienes tareas aún' : 'No se encontraron tareas con los filtros aplicados'}
                     </div>
-                    <p className="text-gray-400">
+                    <p className="text-muted-foreground">
                       {tasks.length === 0 ? 'Crea tu primera tarea para comenzar' : 'Prueba cambiando los filtros'}
                     </p>
                   </Card>

--- a/frontend/src/features/tasks/components/TaskCard.jsx
+++ b/frontend/src/features/tasks/components/TaskCard.jsx
@@ -17,9 +17,9 @@ const TaskCard = ({
   const isOverdue = task.due_date && new Date(task.due_date) < new Date() && !task.completed;
 
   return (
-    <div className={`bg-white border rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow ${
+    <div className={`bg-card border rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow ${
       task.completed ? 'opacity-75' : ''
-    } ${isOverdue ? 'border-red-200 bg-red-50' : 'border-gray-200'}`}>
+    } ${isOverdue ? 'border-red-500 bg-red-50 dark:bg-red-900/20' : 'border-border'}`}>
       <div className="flex items-start justify-between">
         <div className="flex items-start space-x-3 flex-1">
           <button
@@ -30,20 +30,20 @@ const TaskCard = ({
             {task.completed ? (
               <CheckCircle className="h-5 w-5 text-green-500" />
             ) : (
-              <Circle className="h-5 w-5 text-gray-400 hover:text-green-500" />
+              <Circle className="h-5 w-5 text-muted-foreground hover:text-green-500" />
             )}
           </button>
 
           <div className="flex-1 min-w-0">
             <h3 className={`text-lg font-medium ${
-              task.completed ? 'line-through text-gray-500' : 'text-gray-900'
+              task.completed ? 'line-through text-muted-foreground' : 'text-foreground'
             }`}>
               {task.title}
             </h3>
 
             {task.description && (
               <p className={`mt-1 text-sm ${
-                task.completed ? 'line-through text-gray-400' : 'text-gray-600'
+                task.completed ? 'line-through text-muted-foreground' : 'text-muted-foreground'
               }`}>
                 {task.description}
               </p>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -62,12 +62,12 @@
 
 .dark {
   /* Base Colors - Dark Mode */
-  --background: oklch(0.12 0 0);
+  --background: oklch(0.21 0.04 265); /* Bluish dark (Gray 900) */
   --foreground: oklch(0.985 0 0);
 
-  --card: oklch(0.16 0 0);
+  --card: oklch(0.28 0.04 260); /* Slightly lighter bluish dark (Gray 800) */
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.16 0 0);
+  --popover: oklch(0.28 0.04 260);
   --popover-foreground: oklch(0.985 0 0);
 
   /* Brand Colors - Dark Mode */
@@ -96,7 +96,7 @@
   --chart-4: oklch(0.35 0.15 145);
   --chart-5: oklch(0.25 0.15 145);
 
-  --sidebar: oklch(0.14 0 0);
+  --sidebar: oklch(0.21 0.04 265); /* Matches background */
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.65 0.15 145);
   --sidebar-primary-foreground: oklch(0.145 0 0);

--- a/frontend/src/shared/components/StreakWidget.jsx
+++ b/frontend/src/shared/components/StreakWidget.jsx
@@ -66,16 +66,16 @@ const StreakWidget = () => {
 
   if (loading) {
     return (
-      <div className="bg-white rounded-xl shadow-sm p-6">
-        <div className="text-center text-gray-500">Cargando racha...</div>
+      <div className="bg-card rounded-xl shadow-sm p-6">
+        <div className="text-center text-muted-foreground">Cargando racha...</div>
       </div>
     );
   }
 
   if (!streakData) {
     return (
-      <div className="bg-white rounded-xl shadow-sm p-6">
-        <div className="text-center text-gray-500">No se pudo cargar la información de racha</div>
+      <div className="bg-card rounded-xl shadow-sm p-6">
+        <div className="text-center text-muted-foreground">No se pudo cargar la información de racha</div>
       </div>
     );
   }
@@ -84,13 +84,13 @@ const StreakWidget = () => {
     new Date(streakData.lastCompletedDate).toDateString() === new Date().toDateString();
 
   return (
-    <div className="bg-white rounded-xl shadow-sm p-6">
+    <div className="bg-card rounded-xl shadow-sm p-6">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-bold text-gray-800 flex items-center">
+        <h3 className="text-lg font-bold text-foreground flex items-center">
           <Flame className="mr-2 text-orange-500" size={20} />
           Mi Racha
         </h3>
-        <div className="flex items-center text-sm text-gray-600">
+        <div className="flex items-center text-sm text-muted-foreground">
           <Target size={16} className="mr-1" />
           Meta: {streakData.dailyGoal} tareas/día
         </div>
@@ -99,11 +99,11 @@ const StreakWidget = () => {
       {/* Streak counter */}
       <div className="text-center mb-4">
         <div className={`text-6xl font-bold mb-2 ${
-          animatedStreak > 0 ? 'text-orange-500' : 'text-gray-400'
+          animatedStreak > 0 ? 'text-orange-500' : 'text-muted-foreground'
         }`}>
           {animatedStreak}
         </div>
-        <div className="text-sm text-gray-600">
+        <div className="text-sm text-muted-foreground">
           {animatedStreak === 1 ? 'día consecutivo' : 'días consecutivos'}
         </div>
       </div>
@@ -116,7 +116,7 @@ const StreakWidget = () => {
             ¡Racha activa!
           </div>
         ) : (
-          <div className="inline-flex items-center px-3 py-1 rounded-full bg-gray-100 text-gray-600 text-sm">
+          <div className="inline-flex items-center px-3 py-1 rounded-full bg-muted text-muted-foreground text-sm">
             <Calendar size={14} className="mr-1" />
             Completa tareas hoy para mantener la racha
           </div>
@@ -134,7 +134,7 @@ const StreakWidget = () => {
 
       {/* Last completed date */}
       {streakData.lastCompletedDate && (
-        <div className="text-center text-xs text-gray-500 mt-2">
+        <div className="text-center text-xs text-muted-foreground mt-2">
           Última: {new Date(streakData.lastCompletedDate).toLocaleDateString('es-ES')}
         </div>
       )}


### PR DESCRIPTION
Updated the global dark mode CSS variables in `frontend/src/index.css` to use a bluish-dark palette (approx Gray 900) instead of pure black, aligning the sidebar and main content with the Settings view aesthetic. Refactored `SettingsPage.jsx` to use semantic `bg-background` and `bg-card` classes, ensuring consistent theming across the application.

Key changes:
- Set `--background` and `--sidebar` to `oklch(0.21 0.04 265)`.
- Set `--card` and `--popover` to `oklch(0.28 0.04 260)`.
- Removed hardcoded `bg-gray-900` from SettingsPage.jsx.