### PR TITLE
Standardize frontend loading spinner across all views

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,7 @@ import TeacherDiagramsPage from './features/teacher/TeacherDiagramsPage';
 import TeacherReviewsPage from './features/teacher/TeacherReviewsPage';
 import TeacherEditTaskPage from './features/teacher/TeacherEditTaskPage';
 import TeacherCalendarPage from './features/teacher/TeacherCalendarPage';
+import Loading from './ui/loading';
 import { Toaster } from 'sonner';
 
  // Protected Route component
@@ -38,11 +39,7 @@ import { Toaster } from 'sonner';
    }
  
    if (loading) {
-     return (
-       <div className="min-h-screen flex items-center justify-center">
-         <div className="text-xl">Cargando...</div>
-       </div>
-     );
+     return <Loading message="Cargando..." />;
    }
  
    return isAuthenticated ? children : <Navigate to="/" />;

--- a/frontend/src/components/diagrams/DiagramEditor.jsx
+++ b/frontend/src/components/diagrams/DiagramEditor.jsx
@@ -4,6 +4,7 @@ import { Button } from '../../ui/button';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
 import Editor from '@monaco-editor/react';
+import Loading from '../../ui/loading';
 import MermaidRenderer from './MermaidRenderer';
 
 const defaultCode = `graph TD
@@ -100,7 +101,7 @@ export default function DiagramEditor({ open, onOpenChange, initialData, onSave 
                       scrollBeyondLastLine: false,
                       wordWrap: 'on',
                     }}
-                    loading={<div className="p-4 text-sm text-gray-500">Cargando editor...</div>}
+                    loading={<Loading message="Cargando editor..." fullScreen={false} />}
                   />
                </div>
             </div>

--- a/frontend/src/features/categories/CategoryManagement.jsx
+++ b/frontend/src/features/categories/CategoryManagement.jsx
@@ -6,6 +6,7 @@ import { Card } from '../../ui/card';
 import { Badge } from '../../ui/badge';
 import { Progress } from '../../ui/progress';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '../../ui/dialog';
+import Loading from '../../ui/loading';
 import apiClient from '../../shared/api/client';
 import { toast } from 'sonner';
 
@@ -160,7 +161,7 @@ const CategoryManagement = () => {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="text-lg text-gray-600">Cargando categorías...</div>
+        <Loading message="Cargando categorías..." fullScreen={false} />
       </div>
     );
   }

--- a/frontend/src/features/courses/StudentCourseDetailPage.jsx
+++ b/frontend/src/features/courses/StudentCourseDetailPage.jsx
@@ -12,6 +12,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Input } from '../../ui/input'
 import { Label } from '../../ui/label'
 import { toast } from 'sonner'
+import Loading from '../../ui/loading'
 import { FileText, Users, Clock, Upload, CheckCircle } from 'lucide-react'
 
 export default function StudentCourseDetailPage() {
@@ -102,7 +103,7 @@ export default function StudentCourseDetailPage() {
       }
   }
 
-  if (loading) return <div className="p-6">Cargando...</div>
+  if (loading) return <Loading message="Cargando..." />
   if (!course) return <div className="p-6">Curso no encontrado</div>
 
   return (

--- a/frontend/src/features/courses/StudentCoursesPage.jsx
+++ b/frontend/src/features/courses/StudentCoursesPage.jsx
@@ -6,6 +6,7 @@ import { useCourses } from '../../hooks/useCourses'
 import { useEnrollments } from '../../hooks/useEnrollments'
 import { toast } from 'sonner'
 import { Input } from '../../ui/input'
+import Loading from '../../ui/loading'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '../../ui/dialog'
 
 export default function StudentCoursesPage() {
@@ -27,7 +28,7 @@ export default function StudentCoursesPage() {
       }
   }
 
-  if (loading) return <div className="p-6">Cargando cursos...</div>
+  if (loading) return <Loading message="Cargando cursos..." />
 
   return (
     <div className="p-6 space-y-6">

--- a/frontend/src/features/notes/NotesPage.jsx
+++ b/frontend/src/features/notes/NotesPage.jsx
@@ -9,6 +9,7 @@ import { Badge } from '../../ui/badge'
 import { Textarea } from '../../ui/textarea'
 import { Label } from '../../ui/label'
 import { Switch } from '../../ui/switch'
+import Loading from '../../ui/loading'
 import apiClient from '../../shared/api/client'
 
 function getCurrentDate() {
@@ -434,14 +435,7 @@ export default function NotesPage() {
   )
 
   if (loading) {
-    return (
-      <div className="min-h-screen bg-[#F6F7FB] flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600">Cargando notas...</p>
-        </div>
-      </div>
-    )
+    return <Loading message="Cargando notas..." />
   }
 
   if (error) {

--- a/frontend/src/features/profile/ProfilePage.jsx
+++ b/frontend/src/features/profile/ProfilePage.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { User, Mail, Calendar, Edit3, Save, X, Sparkles } from 'lucide-react';
 import { Button } from '../../ui/button'
 import { Input } from '../../ui/input'
+import Loading from '../../ui/loading'
 
 const ProfilePage = () => {
   const [user, setUser] = useState(null);
@@ -127,11 +128,7 @@ const ProfilePage = () => {
   };
 
   if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-xl">Cargando perfil...</div>
-      </div>
-    );
+    return <Loading message="Cargando perfil..." />;
   }
 
   return (

--- a/frontend/src/features/settings/SettingsPage.jsx
+++ b/frontend/src/features/settings/SettingsPage.jsx
@@ -16,6 +16,7 @@ import {
 import { useTheme } from '../../context/themeContext'
 import { useAuth } from '../../context/AuthContext'
 import { supabase } from '../../shared/api/supabase'
+import Loading from '../../ui/loading'
 import { toast } from 'sonner'
 
 function getCurrentDate() {
@@ -442,7 +443,7 @@ export default function SettingsPage() {
                 </h2>
                 {loading ? (
                   <div className="text-center py-8">
-                    <div className="text-xl">Cargando información del perfil...</div>
+                    <Loading message="Cargando información del perfil..." fullScreen={false} />
                   </div>
                 ) : error ? (
                   <div className="text-center py-8">

--- a/frontend/src/features/stats/StatsPage.jsx
+++ b/frontend/src/features/stats/StatsPage.jsx
@@ -4,6 +4,7 @@ import { Bell, MessageSquare, TrendingUp, CheckSquare, Target, Award, Settings }
 import { Button } from '../../ui/button'
 import { Card } from '../../ui/card'
 import apiClient from '../../shared/api/client'
+import Loading from '../../ui/loading'
 import { ManageSubjectsDialog } from '../subjects/components/ManageSubjectsDialog'
 
 function getCurrentDate() {
@@ -121,7 +122,7 @@ export default function StatsPage() {
   const strokeDasharray = `${(completionPercent / 100) * circumference} ${circumference}`;
 
   if (loading) {
-     return <div className="min-h-screen flex items-center justify-center bg-[#F6F7FB]">Cargando estadísticas...</div>;
+     return <Loading message="Cargando estadísticas..." />;
   }
 
   return (

--- a/frontend/src/features/subjects/components/ManageSubjectsDialog.jsx
+++ b/frontend/src/features/subjects/components/ManageSubjectsDialog.jsx
@@ -14,6 +14,7 @@ import { Button } from '../../../ui/button';
 import { Input } from '../../../ui/input';
 import { Label } from '../../../ui/label';
 import { ScrollArea } from '../../../ui/scroll-area';
+import Loading from '../../../ui/loading';
 import { BookOpen, Plus, Loader2, Trash2 } from 'lucide-react';
 
 const COLORS = [
@@ -173,7 +174,7 @@ export function ManageSubjectsDialog({ trigger, onUpdate }) {
             <h3 className="font-medium text-sm mb-3">Materias Activas ({subjects.length})</h3>
             <ScrollArea className="flex-1 pr-4">
               {loading ? (
-                <div className="text-center py-8 text-muted-foreground">Cargando...</div>
+                <Loading message="Cargando..." fullScreen={false} />
               ) : subjects.length === 0 ? (
                 <div className="text-center py-8 text-muted-foreground border-dashed border-2 rounded-lg">
                   No hay materias registradas.

--- a/frontend/src/features/tasks/TaskPage.jsx
+++ b/frontend/src/features/tasks/TaskPage.jsx
@@ -14,6 +14,7 @@ import { Badge } from '../../ui/badge';
 import { Button } from '../../ui/button';
 import { Card } from '../../ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '../../ui/dialog';
+import Loading from '../../ui/loading';
 import './TaskTabs.css';
 
 const TaskPage = () => {
@@ -144,11 +145,7 @@ const TaskPage = () => {
   });
 
   if (loading && tasks.length === 0) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-xl">Cargando tareas...</div>
-      </div>
-    );
+    return <Loading message="Cargando tareas..." />;
   }
 
   return (

--- a/frontend/src/features/tasks/components/TaskListView.jsx
+++ b/frontend/src/features/tasks/components/TaskListView.jsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTasks } from '../hooks/useTasks';
 import { Check, Calendar, List } from 'lucide-react';
+import Loading from '../../../ui/loading';
 import AddTaskForm from './AddTaskForm';
 
 const TaskListView = () => {
@@ -71,11 +72,7 @@ const TaskListView = () => {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-xl text-gray-600">Cargando tareas...</div>
-      </div>
-    );
+    return <Loading message="Cargando tareas..." fullScreen={false} />;
   }
 
   if (error) {

--- a/frontend/src/features/teacher/TeacherCourseDetailPage.jsx
+++ b/frontend/src/features/teacher/TeacherCourseDetailPage.jsx
@@ -9,6 +9,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../ui/tabs'
 import { Plus, Users, FileText, ClipboardList } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '../../ui/dialog'
 import { Input } from '../../ui/input'
+import Loading from '../../ui/loading'
 import { toast } from 'sonner'
 
 export default function TeacherCourseDetailPage() {
@@ -59,7 +60,7 @@ export default function TeacherCourseDetailPage() {
       }
   }
 
-  if (loading) return <div className="p-6">Cargando...</div>
+  if (loading) return <Loading message="Cargando..." />
   if (!course) return <div className="p-6">Curso no encontrado</div>
 
   return (

--- a/frontend/src/features/teacher/TeacherCoursesPage.jsx
+++ b/frontend/src/features/teacher/TeacherCoursesPage.jsx
@@ -6,6 +6,7 @@ import { useCourses } from '../../hooks/useCourses'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '../../ui/dialog'
 import { Input } from '../../ui/input'
 import { Textarea } from '../../ui/textarea'
+import Loading from '../../ui/loading'
 import { toast } from 'sonner'
 
 export default function TeacherCoursesPage() {
@@ -27,7 +28,7 @@ export default function TeacherCoursesPage() {
       }
   }
 
-  if (loading) return <div className="p-6">Cargando cursos...</div>
+  if (loading) return <Loading message="Cargando cursos..." />
 
   return (
     <div className="p-6 space-y-6">

--- a/frontend/src/features/teacher/TeacherEditTaskPage.jsx
+++ b/frontend/src/features/teacher/TeacherEditTaskPage.jsx
@@ -7,6 +7,7 @@ import { Input } from '../../ui/input'
 import { Textarea } from '../../ui/textarea'
 import { Label } from '../../ui/label'
 import { Switch } from '../../ui/switch'
+import Loading from '../../ui/loading'
 import { toast } from 'sonner'
 import { ArrowLeft } from 'lucide-react'
 
@@ -81,7 +82,7 @@ export default function TeacherEditTaskPage() {
       }
   }
 
-  if (loading) return <div className="p-6">Cargando...</div>
+  if (loading) return <Loading message="Cargando..." />
 
   return (
     <div className="p-6 max-w-3xl mx-auto space-y-6">

--- a/frontend/src/features/teacher/TeacherReviewsPage.jsx
+++ b/frontend/src/features/teacher/TeacherReviewsPage.jsx
@@ -7,6 +7,7 @@ import { Input } from '../../ui/input'
 import { Textarea } from '../../ui/textarea'
 import { Card, CardContent } from '../../ui/card'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '../../ui/dialog'
+import Loading from '../../ui/loading'
 import { toast } from 'sonner'
 import { ArrowLeft, ExternalLink, CheckCircle, Clock } from 'lucide-react'
 
@@ -70,7 +71,7 @@ export default function TeacherReviewsPage() {
       setIsGradeOpen(true)
   }
 
-  if (loading) return <div className="p-6">Cargando...</div>
+  if (loading) return <Loading message="Cargando..." />
 
   return (
     <div className="p-6 space-y-6">

--- a/frontend/src/shared/components/StreakWidget.jsx
+++ b/frontend/src/shared/components/StreakWidget.jsx
@@ -1,6 +1,7 @@
 // StreakWidget - Widget mejorado con animación y mejor diseño
 import React, { useState, useEffect } from 'react';
 import { Flame, Target, Calendar } from 'lucide-react';
+import Loading from '../../ui/loading';
 import apiClient from '../api/client';
 
 const StreakWidget = () => {
@@ -67,7 +68,7 @@ const StreakWidget = () => {
   if (loading) {
     return (
       <div className="bg-card rounded-xl shadow-sm p-6">
-        <div className="text-center text-muted-foreground">Cargando racha...</div>
+        <Loading message="Cargando racha..." fullScreen={false} />
       </div>
     );
   }

--- a/frontend/src/ui/loading.jsx
+++ b/frontend/src/ui/loading.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export default function Loading({ message = 'Cargando...', fullScreen = true }) {
+  const containerClass = fullScreen
+    ? "min-h-screen bg-[#F6F7FB] flex items-center justify-center"
+    : "flex items-center justify-center py-12"
+
+  return (
+    <div className={containerClass}>
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600 mx-auto"></div>
+        <p className="mt-4 text-gray-600">{message}</p>
+      </div>
+    </div>
+  )
+}

--- a/frontend_output.log
+++ b/frontend_output.log
@@ -1,0 +1,7 @@
+
+> captus-monorepo@0.1.0 frontend:dev
+> npm run dev --prefix ./frontend
+
+
+> captus-frontend@0.1.0 dev
+> vite


### PR DESCRIPTION
- Created reusable `Loading` component in `frontend/src/ui/loading.jsx` matching the design from `NotesPage`.
- Updated `NotesPage.jsx` to use the new `Loading` component.
- Updated page-level views (`TaskPage`, `StudentCoursesPage`, `StudentCourseDetailPage`, `ProfilePage`, `SettingsPage`, `StatsPage`, `TeacherCoursesPage`, `TeacherCourseDetailPage`, `TeacherEditTaskPage`, `TeacherReviewsPage`, `App.jsx`) to use the `Loading` component (default fullscreen).
- Updated component-level views (`CategoryManagement`, `ManageSubjectsDialog`, `StreakWidget`, `DiagramEditor`, `TaskListView`) to use the `Loading` component with `fullScreen={false}`.
- Verified changes with Playwright script.