### PR TITLE
fix(backend): alinea la ruta de la API de IA con el resto del backend

### DIFF
--- a/backend/src/ai/agents/tutorAgent.js
+++ b/backend/src/ai/agents/tutorAgent.js
@@ -32,17 +32,25 @@ export const tutorAgent = async (message, userId) => {
   }
 
   console.info("[AI/Tutor] Switch to Groq (Simple Query)");
-  // Consultas rápidas/teóricas usan Groq (sin tools).
-  const response = await groq.chat.completions.create({
-    model: MODEL_FAST,
-    messages: [
-      {
-        role: "system",
-        content: "Eres un tutor académico experto y conciso. Responde brevemente.",
-      },
-      { role: "user", content: message },
-    ],
-  });
-
-  return response.choices[0].message.content;
+  try {
+    // Consultas rápidas/teóricas usan Groq (sin tools).
+    const response = await groq.chat.completions.create({
+      model: MODEL_FAST,
+      messages: [
+        {
+          role: "system",
+          content: "Eres un tutor académico experto y conciso. Responde brevemente.",
+        },
+        { role: "user", content: message },
+      ],
+    });
+    return response.choices[0].message.content;
+  } catch (err) {
+    if (err.status === 401) {
+      console.error("[AI/Tutor] Groq authentication failed. Check API Key.", err);
+      return "Error: La clave de API de Groq no es válida. Por favor, verifica tu configuración.";
+    }
+    console.error("[AI/Tutor] Groq request failed.", err);
+    return "Lo siento, el servicio de chat rápido no está disponible en este momento. Aún puedes usar los comandos para crear tareas, notas, etc.";
+  }
 };

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -105,7 +105,7 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // AI routes
 if (ENV_OK && supabaseAdmin) {
-  app.use('/ai', verifySupabaseToken, aiRouter);
+  app.use('/api/ai', verifySupabaseToken, aiRouter);
 }
 
 // Extended API routes


### PR DESCRIPTION
El chatbot del frontend no podía comunicarse con el backend porque intentaba acceder a la ruta `/api/ai/chat`, pero el router de la IA estaba montado incorrectamente en `/ai/chat`.

Este cambio mueve el router de la IA para que se sirva desde `/api/ai`, en línea con el resto de las rutas de la API. Esto soluciona la desconexión y permite que el frontend se comunique correctamente con el servicio de IA.